### PR TITLE
Change action bar layout to have action-bar-title

### DIFF
--- a/home/home.component.html
+++ b/home/home.component.html
@@ -1,4 +1,5 @@
-<ActionBar title="Home" class="action-bar">
+<ActionBar class="action-bar">
+    <Label class="action-bar-title" text="Home"></Label>
 </ActionBar>
 
 <GridLayout class="page">


### PR DESCRIPTION
Change action bar layout to use the same layout as the other templates. In this way the page title will be always center. Otherwise once will be center, another time - left