### PR TITLE
Reference NativeScriptCommonModule

### DIFF
--- a/home/home.module.ts
+++ b/home/home.module.ts
@@ -1,12 +1,12 @@
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
-import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { NativeScriptCommonModule } from "nativescript-angular/common";
 
 import { HomeRoutingModule } from "./home-routing.module";
 import { HomeComponent } from "./home.component";
 
 @NgModule({
     imports: [
-        NativeScriptModule,
+        NativeScriptCommonModule,
         HomeRoutingModule
     ],
     declarations: [


### PR DESCRIPTION
Breaking change in [nativescript-angular 4.2.0](https://github.com/NativeScript/nativescript-angular/blob/master/CHANGELOG.md): NativeScriptModule should be imported only in the root application module. All other NgModules in the app (both feature and lazy-loaded ones) should import the NativeScriptCommonModule instead.

http://teampulse.telerik.com/view#item/348892